### PR TITLE
fix(nonexistent_property): do not concat with className when it is a …

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,7 @@ const createClassName = (foo, foo2, foo3) => {
   return ( componentProps = {} ) => {
 
     const getClassName = (name, className) => {
+      if(!componentProps[name]) return '';
       if(!className) className = name;
       if(!keepComponentProps) delete componentProps[name];
 


### PR DESCRIPTION
…nonexistent property

Do not concat with className when it is a nonexistent property.